### PR TITLE
fix: update routes to fix deletion requests

### DIFF
--- a/docs/api-swagger.yaml
+++ b/docs/api-swagger.yaml
@@ -15,7 +15,7 @@ tags:
 schemes:
   - http
 paths:
-  "/conversations/{userId}":
+  "/sender/{userId}/conversations/":
     get:
       tags:
         - conversations
@@ -41,6 +41,7 @@ paths:
           description: No conversations found
         "503":
           description: Unavailable
+  "/conversations/{conversationId}":
     post:
       tags:
         - conversations
@@ -52,9 +53,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: userId
+        - name: conversationId
           in: path
-          description: ID of the user
+          description: ID of the conversation
           required: true
           type: string
         - in: body
@@ -78,7 +79,6 @@ paths:
           description: Invalid input
         "503":
           description: Unavailable
-  "/conversation/{conversationId}":
     delete:
       tags:
         - conversations
@@ -98,7 +98,7 @@ paths:
           description: Success
         "503":
           description: Unavailable
-  "/messages/{conversationId}":
+  "/conversation/{conversationId}/messages/":
     get:
       tags:
         - messages
@@ -162,7 +162,7 @@ paths:
           description: Invalid input
         "503":
           description: Unavailable
-  "/message/{messageId}":
+  "/messages/{messageId}":
     delete:
       tags:
         - messages

--- a/src/server/routes.json
+++ b/src/server/routes.json
@@ -1,7 +1,5 @@
 {
-  "/conversations/:id": "/conversations?senderId=:id",
-  "/conversation/:id": "/conversations?id=:id",
-  "/messages/:id": "/messages?conversationId=:id",
-  "/message/:id": "/messages?id=:id",
+  "/sender/:id/conversations": "/conversations?senderId=:id",
+  "/conversation/:id/messages/": "/messages?conversationId=:id",
   "/user/:id": "/users?id=:id"
 }


### PR DESCRIPTION
This allow users to delete conversations and messages

I rename some routes with more logic : 

`/sender/{senderID}/conversations` =>  Get all conversations for a userId

`/conversation/{conversationID}/messages/` => Get all message for a conversation 

